### PR TITLE
Fix DRX and BAM command timing

### DIFF
--- a/scripts/ndp/Ndp.py
+++ b/scripts/ndp/Ndp.py
@@ -1918,7 +1918,8 @@ class MsgProcessor(ConsumerThread):
                         self.state['lastlog'] = "STP: Invalid beam"
                         exit_status = 99
                     else:
-                        self.drx.messenger.drxConfig(0, beam-1, 3-1, 0, 0, 0, 0)
+                        stp_slot = msg.mjd*86400 + msg.mpm//1000 - 3506716800
+                        self.drx.messenger.drxConfig(stp_slot, beam-1, 3-1, 0, 0, 0, 0)
                         for tuning in range(self.drx.ntuning):
                             self.drx.cur_freq[(beam-1)*self.drx.ntuning + tuning] = 0
                             self.drx.cur_filt[(beam-1)*self.drx.ntuning + tuning] = 0

--- a/scripts/ndp/Ndp.py
+++ b/scripts/ndp/Ndp.py
@@ -159,7 +159,7 @@ class TbfCommand(object):
 
 class Tbf(SlotCommandProcessor):
     def __init__(self, config, log, messenger, servers):
-        SlotCommandProcessor.__init__(self, 'TBF', TbfCommand)
+        SlotCommandProcessor.__init__(self, 'TBF', TbfCommand, exec_delay=1)
         self.config  = config
         self.log     = log
         self.messenger = messenger

--- a/scripts/ndp/Ndp.py
+++ b/scripts/ndp/Ndp.py
@@ -159,7 +159,7 @@ class TbfCommand(object):
 
 class Tbf(SlotCommandProcessor):
     def __init__(self, config, log, messenger, servers):
-        SlotCommandProcessor.__init__(self, 'TBF', TbfCommand, exec_delay=1)
+        SlotCommandProcessor.__init__(self, 'TBF', TbfCommand)
         self.config  = config
         self.log     = log
         self.messenger = messenger

--- a/scripts/ndp_drx.py
+++ b/scripts/ndp_drx.py
@@ -616,7 +616,7 @@ class BeamformerOp(object):
             ## Is this command from the future?
             if pipeline_time < config_time:
                 ### Looks like it, save it for later
-                idx = bisect.bisect_right(self._pending, (config_time, None))
+                idx = bisect.bisect_right(self._pending, (config_time,))
                 self._pending.insert(idx, (config_time, config))
                 config = None
                 
@@ -882,7 +882,7 @@ class CorrelatorOp(object):
             ## Is this command from the future?
             if pipeline_time < config_time:
                 ### Looks like it, save it for later
-                idx = bisect.bisect_right(self._pending, (config_time, None))
+                idx = bisect.bisect_right(self._pending, (config_time,))
                 self._pending.insert(idx, (config_time, config))
                 config = None
                 

--- a/scripts/ndp_tengine.py
+++ b/scripts/ndp_tengine.py
@@ -494,13 +494,13 @@ class TEngineOp(object):
         # Can we act on this configuration change now?
         if config:
             ## Pull out the beam (something unique to DRX/BAM/COR)
-            beam = config[0]
+            beam = config[1]
             if beam != self.beam:
                 return False
                 
-            ## Set the configuration time - DRX commands are for the specified subslot in the next second
-            subslot = config[-1] / 100.0
-            config_time = int(time.time()) + 1 + subslot
+            ## Set the configuration time - DRX commands are for the specified subslot two seconds from when it was received
+            slot = config[0] + config[-1] / 100.0
+            config_time = slot + 2
             
             ## Is this command from the future?
             if pipeline_time < config_time:
@@ -531,7 +531,7 @@ class TEngineOp(object):
                 
         if config:
             self.log.info("TEngine: New configuration received for beam %i, tuning %i (delta = %.1f subslots)", config[0], config[1], (pipeline_time-config_time)*100.0)
-            beam, tuning, freq, filt, gain, subslot = config
+            _, beam, tuning, freq, filt, gain, subslot = config
             if beam != self.beam:
                 self.log.info("TEngine: Not for this beam, skipping")
                 return False

--- a/scripts/ndp_tengine.py
+++ b/scripts/ndp_tengine.py
@@ -505,7 +505,8 @@ class TEngineOp(object):
             ## Is this command from the future?
             if pipeline_time < config_time:
                 ### Looks like it, save it for later
-                self._pending.append( (config_time, config) )
+                idx = bisect.bisect_right(self._pending, (config_time, None))
+                self._pending.insert(idx, (config_time, config))
                 config = None
                 
                 ### Is there something pending?
@@ -530,7 +531,7 @@ class TEngineOp(object):
                 pass
                 
         if config:
-            self.log.info("TEngine: New configuration received for beam %i, tuning %i (delta = %.1f subslots)", config[0], config[1], (pipeline_time-config_time)*100.0)
+            self.log.info("TEngine: New configuration received for beam %i, tuning %i (delta = %.1f subslots)", config[1], config[2], (pipeline_time-config_time)*100.0)
             _, beam, tuning, freq, filt, gain, subslot = config
             if beam != self.beam:
                 self.log.info("TEngine: Not for this beam, skipping")

--- a/scripts/ndp_tengine.py
+++ b/scripts/ndp_tengine.py
@@ -506,7 +506,7 @@ class TEngineOp(object):
             ## Is this command from the future?
             if pipeline_time < config_time:
                 ### Looks like it, save it for later
-                idx = bisect.bisect_right(self._pending, (config_time, None))
+                idx = bisect.bisect_right(self._pending, (config_time,))
                 self._pending.insert(idx, (config_time, config))
                 config = None
                 

--- a/scripts/ndp_tengine.py
+++ b/scripts/ndp_tengine.py
@@ -27,6 +27,7 @@ import signal
 import logging
 import time
 import os
+import bisect
 import argparse
 import ctypes
 import threading


### PR DESCRIPTION
This PR fixes the DRX and BAM command timing by taking into account the slot when the command was received from MCS.  It also enforces strict time ordering for when the commands are processed.